### PR TITLE
fix ordering of GPIO4/5 pins in ESP-07 and ESP-12

### DIFF
--- a/lio.lbr
+++ b/lio.lbr
@@ -735,8 +735,8 @@ Source: http://www.atmel.com/dyn/resources/prod_documents/doc2593.pdf</descripti
 <smd name="GPIO15" x="8.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="GPIO2" x="6.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="GPIO0" x="4.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
-<smd name="GPIO5" x="2.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
-<smd name="GPIO4" x="0.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
+<smd name="GPIO4" x="2.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
+<smd name="GPIO5" x="0.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="RXD" x="-1.6" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="TXD" x="-3.6" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="REST" x="-3.6" y="-8" dx="2" dy="1" layer="1" rot="R90"/>
@@ -823,8 +823,8 @@ Source: http://www.atmel.com/dyn/resources/prod_documents/doc2593.pdf</descripti
 <smd name="GPIO15" x="8.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="GPIO2" x="6.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="GPIO0" x="4.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
-<smd name="GPIO5" x="2.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
-<smd name="GPIO4" x="0.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
+<smd name="GPIO4" x="2.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
+<smd name="GPIO5" x="0.4" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="RXD" x="-1.6" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="TXD" x="-3.6" y="8" dx="2" dy="1" layer="1" rot="R90"/>
 <smd name="REST" x="-3.6" y="-8" dx="2" dy="1" layer="1" rot="R90"/>


### PR DESCRIPTION
To my understanding, the GPIO5 pin comes next to RX. This is verifiably true at least for my ESP-07 modules. Caused a lot of confusion for me.
